### PR TITLE
(1) pin jinja and markupsafe to lower versions, as newer version have…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 1.2.3 - 2022-06-07
+Tests now rely on a seperate requirements file instead of using fastapi's.
+Flask and Fastapi now rely on PyPi version of tapisservice.
+Tests rely on local tapisservice.
+
 ## 1.2.2 - 2022-05-31
 Fixed issue with core_validate_request_token() that was preventing validate_request_token from working for flask services.
 
@@ -18,4 +23,4 @@ Added testing Dockerfile.
 Packaged tapisservice and released on PyPi.
 
 ## 1.1.0 - 2022-03-01
-This is the initial release of the tapisservice python plugin package for the `tapipy` library. 
+This is the initial release of the tapisservice python plugin package for the `tapisservice` library. 

--- a/Dockerfile-fastapi
+++ b/Dockerfile-fastapi
@@ -8,10 +8,9 @@ ADD requirements-fastapi.txt /home/tapis/tapisservice-requirements.txt
 # TODO -- eventually remove this
 RUN apt-get update && apt-get install -y vim
 
-# Install requirements and tapipy/tapisservice packages.
+# Install requirements and tapipy/tapisservice(inside of requirements.txt) packages.
 RUN pip install -U --no-cache-dir pip && \
-    pip install --no-cache-dir -r /home/tapis/tapisservice-requirements.txt \
-    pip install tapipy tapisservice==1.2.0
+    pip install --no-cache-dir -r /home/tapis/tapisservice-requirements.txt
 
 WORKDIR /home/tapis
 

--- a/Dockerfile-flask
+++ b/Dockerfile-flask
@@ -8,10 +8,9 @@ ADD requirements-flask.txt /home/tapis/tapisservice-requirements.txt
 # TODO -- eventually remove this
 RUN apt-get update && apt-get install -y vim
 
-# Install requirements and tapipy/tapisservice packages.
+# Install requirements and tapipy/tapisservice(inside of requirements.txt) packages.
 RUN pip install -U --no-cache-dir pip && \
-    pip install --no-cache-dir -r /home/tapis/tapisservice-requirements.txt \
-    pip install tapipy tapisservice
+    pip install --no-cache-dir -r /home/tapis/tapisservice-requirements.txt
 
 # Set flask defaults and envs.
 # set default worker class, workers, and threads for gunicorn

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -19,7 +19,7 @@ ADD tests/config-dev-develop.json /home/tapis/config.json
 
 # Add tapisservice files and build with Poetry build.
 ADD . /home/tapis/tapisservice-install-dir
-RUN pip install -r /home/tapis/tapisservice-install-dir/requirements-fastapi.txt
+RUN pip install -r /home/tapis/tapisservice-install-dir/requirements-test.txt
 WORKDIR /home/tapis/tapisservice-install-dir
 RUN poetry build
 WORKDIR /home/tapis/tapisservice-install-dir/dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tapisservice"
-version = "1.2.1"
+version = "1.2.3"
 description = "Python lib for interacting with an instance of the Tapis API Framework's tapisservice plugin."
 license = "BSD-4-Clause"
 authors = ["Joe Stubbs <jstubbs@tacc.utexas.edu>"]

--- a/requirements-fastapi.txt
+++ b/requirements-fastapi.txt
@@ -8,4 +8,4 @@ psycopg
 
 #Tapis
 tapipy==1.2.2
-tapisservice
+tapisservice==1.2.3

--- a/requirements-flask.txt
+++ b/requirements-flask.txt
@@ -16,4 +16,5 @@ openapi-core==0.12.0
 pyjwt
 pycrypto==2.6.1
 cryptography
-tapipy==1.2.1
+tapipy==1.2.2
+tapisservice

--- a/requirements-flask.txt
+++ b/requirements-flask.txt
@@ -17,4 +17,4 @@ pyjwt
 pycrypto==2.6.1
 cryptography
 tapipy==1.2.2
-tapisservice
+tapisservice==1.2.3

--- a/requirements-flask.txt
+++ b/requirements-flask.txt
@@ -1,4 +1,6 @@
-flask==1.1.1
+flask==1.1.4
+jinja2<3.1.0
+markupsafe==2.0.1
 Flask-SQLAlchemy==2.4.0
 flask-migrate==2.5.2
 Flask-RESTful==0.3.7
@@ -6,7 +8,6 @@ Flask-RESTful==0.3.7
 # connexion[swagger-ui]
 alembic==1.0.10
 psycopg2==2.8.2
-requests==2.22.0
 gunicorn==19.9.0
 PyYAML
 jsonschema
@@ -15,4 +16,4 @@ openapi-core==0.12.0
 pyjwt
 pycrypto==2.6.1
 cryptography
-tapipy
+tapipy==1.2.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,9 @@ uvicorn
 alembic
 psycopg
 
+#Testing
+poetry
+pytest
+
 #Tapis
 tapipy==1.2.2
-tapisservice


### PR DESCRIPTION
… broken with flask 1.x; (2) pin tapipy 1.2.1 as not specifying the version was causing it to install v1.0.4 (this could have been because of version conflicts; (3) unpin requests version to remove additional version conflicts between urllib3 and requests.